### PR TITLE
chore(backend): Enable CORS credentials for JWT cookies

### DIFF
--- a/api/core/settings.py
+++ b/api/core/settings.py
@@ -76,6 +76,7 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
 ]
+CORS_ALLOW_CREDENTIALS = True
 
 # Database configuration for PostgreSQL
 DATABASES = {


### PR DESCRIPTION
Set `CORS_ALLOW_CREDENTIALS = True` in Django settings.

This is necessary to allow the frontend application (running on a different origin) to successfully send and receive HttpOnly JWT cookies from the backend API, enabling secure, session-based authentication.