### PR TITLE
feat(auth): Implement token refresh and secure JWT cookie handling

### DIFF
--- a/api/auth/authentication.py
+++ b/api/auth/authentication.py
@@ -1,21 +1,32 @@
-from rest_framework_simplejwt.authentication import JWTAuthentication
 from django.conf import settings
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
 
 class JWTCookieAuthentication(JWTAuthentication):
     """
-    Looks for the Access Token in the HTTP-only cookie defined by
-    SIMPLE_JWT['AUTH_COOKIE'].
+    Looks only for the Access Token in the HTTP-only cookie.
+    If the token is expired/invalid, it returns None/None to allow the
+    view permission checks to return the 401 or 403, as expected.
     """
     def authenticate(self, request):
-        # 1. Check for token in the designated cookie
+        # Look for the token in the designated cookie
         raw_token = request.COOKIES.get(settings.SIMPLE_JWT['AUTH_COOKIE'])
 
         if raw_token:
-            # If found, retrieve the user and token information
-            validated_token = self.get_validated_token(raw_token)
-            return self.get_user(validated_token), validated_token
+            try:
+                # Attempt to validate the token
+                validated_token = self.get_validated_token(raw_token)
+                # Success: Return the user and validated token
+                return self.get_user(validated_token), validated_token
+            except (InvalidToken, TokenError):
+                # IMPORTANT: If the token is invalid or expired,
+                # we return None to indicate no authentication was provided.
+                # This allows DRF to proceed to permission checks and ultimately
+                # return a 401 if the view requires IsAuthenticated.
+                return None
 
-        # Fallback to default header authentication if the cookie isn't present
-        # (optional, but good practice for API clients)
-        return super().authenticate(request)
+        # If no cookie token is found, return None
+        # Do NOT fall back to super().authenticate(request) as it checks headers
+        # which can confuse a cookie-only API.
+        return None

--- a/api/users/utils.py
+++ b/api/users/utils.py
@@ -1,0 +1,25 @@
+from asgiref.sync import sync_to_async
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
+
+
+@sync_to_async
+def get_refreshed_tokens_sync(refresh_token):
+    """
+    Synchronous wrapper function to perform the blocking token refresh logic.
+    This function will be run in a separate thread.
+    """
+    serializer = TokenRefreshSerializer(data={'refresh': refresh_token})
+    serializer.is_valid(raise_exception=True)
+
+    # Extract access and optional new refresh token
+    validated = getattr(serializer, 'validated_data', None) or {}
+    new_access_token = validated.get('access')
+
+    # Optionally, retrieve a new refresh token if rotation is enabled
+    new_refresh_token = validated.get('refresh')
+
+    if not new_access_token:
+        raise AuthenticationFailed('Failed to refresh access token.')
+
+    return new_access_token, new_refresh_token


### PR DESCRIPTION
Enhance the security and functionality of the JWT cookie-based authentication system by implementing the token refresh endpoint and refining the authentication backend.

Key changes:
- Created the `RefreshTokenView` to securely generate a new access token (and optionally a new refresh token if rotation is enabled) using the refresh token stored in an HttpOnly cookie.
- Disabled DRF authentication classes and permissions on `RefreshTokenView` to allow it to process the refresh token cookie without requiring a valid access token first.
- Introduced `get_refreshed_tokens_sync` utility for performing the synchronous token refresh logic within the asynchronous `RefreshTokenView`.
- Updated `JWTCookieAuthentication` to explicitly catch `InvalidToken` or `TokenError` and return `None`, ensuring DRF correctly handles expired or invalid tokens by returning a 401 status, instead of raising an unhandled exception.
- Removed fallback to header authentication in `JWTCookieAuthentication`.