### PR TITLE
feat(users): Add endpoint for fetching current user status

### DIFF
--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from users.views import LoginView, RefreshTokenView
+from users.views import LoginView, RefreshTokenView, UserStatusView
 
 
 urlpatterns = [
     path('login/', LoginView.as_view(), name='login'),
     path('token/refresh/', RefreshTokenView.as_view(), name='token_refresh'),
+    path('status/', UserStatusView.as_view(), name='user-status'),
     # ... other user-related endpoints
 ]


### PR DESCRIPTION
Introduce a new authenticated API endpoint `/users/status/` to retrieve the details of the currently logged-in user.

- Adds `UserStatusView` which uses `IsAuthenticated` to ensure a valid JWT cookie is present.
- Serializes `request.user` to return structured user data (ID, username, email, is_admin).
- Updates `LoginView` to return the serialized user data directly, standardizing the response payload.
- Registers the new `user-status` URL.